### PR TITLE
Add Java 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.3
+  clojure: lambdaisland/clojure@0.0.4
 
 commands:
   checkout_and_run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.2
+  clojure: lambdaisland/clojure@0.0.3
 
 commands:
   checkout_and_run:
@@ -26,6 +26,10 @@ commands:
                 flags: clj
 
 jobs:
+  java-16-clojure-1_10:
+    executor: clojure/openjdk16
+    steps: [{checkout_and_run: {clojure_version: "1.10.1"}}]
+    
   java-15-clojure-1_10:
     executor: clojure/openjdk15
     steps: [{checkout_and_run: {clojure_version: "1.10.1"}}]
@@ -41,6 +45,7 @@ jobs:
 workflows:
   kaocha_test:
     jobs:
+      - java-16-clojure-1_10
       - java-15-clojure-1_10
       - java-11-clojure-1_10
       - java-8-clojure-1_10


### PR DESCRIPTION
Adds Java 16.

FYI on versions, c/o Wikipedia:


Version | Release date | End of Free Public Updates | Extended Support Until
-- | -- | -- | --
Java SE 8 (LTS) | March 2014 | January 2019 for Oracle (commercial)December 2030 for Oracle (non-commercial)December 2030 for ZuluAt least May 2026 for AdoptOpenJDKAt least May 2026 for Amazon Corretto | December 2030
Java SE 11 (LTS) | September 2018 | September 2027 for ZuluAt least October 2024 for AdoptOpenJDKAt least September 2027 for Amazon Corretto | September 2026,or September 2027 for e.g. Zulu[8]
Java SE 15 | September 2020 | March 2021 for OpenJDK, March 2023 for Zulu[8] | N/A
Java SE 16 | March 2021 | September 2021 for OpenJDK | N/A
Java SE 17 (LTS) | September 2021 | September 2030 for Zulu | TBA

