### PR TITLE
Fix round-trip test

### DIFF
--- a/test/lambdaisland/deep_diff2/diff_test.cljc
+++ b/test/lambdaisland/deep_diff2/diff_test.cljc
@@ -199,7 +199,8 @@
 ;; (not= ##NaN ##NaN), which messes up test results
 ;; https://stackoverflow.com/questions/16983955/check-for-nan-in-clojurescript
 (defn NaN? [node]
-  #?(:clj false
+;; Need to confirm that it's a Double first.
+  #?(:clj (and (instance? Double node) (Double/isNaN node))
      :cljs
      (and (= (.call js/toString node) (str "[object Number]"))
           (js/eval (str node " != +" node )))))


### PR DESCRIPTION
Occasionally the round-trip-diff test would fail in Clojure because we weren't checking for NaNs in Clojure so we'd generate forms that couldn't be compared. Fixes #27.