### PR TITLE
Convert to test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,5 +43,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              os: [clojure/openjdk16, clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
+              os: [clojure/openjdk19, clojure/openjdk17, clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
               clojure_version: ["1.10.3", "1.11.1"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.4
+  kaocha: lambdaisland/kaocha@0.0.3
+  clojure: lambdaisland/clojure@0.0.8
 
 commands:
   checkout_and_run:
@@ -26,26 +26,22 @@ commands:
                 flags: clj
 
 jobs:
-  java-16-clojure-1_10:
-    executor: clojure/openjdk16
-    steps: [{checkout_and_run: {clojure_version: "1.10.1"}}]
-    
-  java-15-clojure-1_10:
-    executor: clojure/openjdk15
-    steps: [{checkout_and_run: {clojure_version: "1.10.1"}}]
-    
-  java-11-clojure-1_10:
-    executor: clojure/openjdk11
-    steps: [{checkout_and_run: {clojure_version: "1.10.1"}}]
-
-  java-8-clojure-1_10:
-    executor: clojure/openjdk8
-    steps: [{checkout_and_run: {clojure_version: "1.10.1"}}]
+  test:
+    parameters:
+      os:
+        type: executor
+      clojure_version:
+        type: string
+    executor: << parameters.os >>
+    steps:
+      - checkout_and_run:
+          clojure_version: << parameters.clojure_version >>
 
 workflows:
   kaocha_test:
     jobs:
-      - java-16-clojure-1_10
-      - java-15-clojure-1_10
-      - java-11-clojure-1_10
-      - java-8-clojure-1_10
+      - test:
+          matrix:
+            parameters:
+              os: [clojure/openjdk16, clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
+              clojure_version: ["1.10.3", "1.11.1"]

--- a/deps.edn
+++ b/deps.edn
@@ -18,7 +18,7 @@
 
            :test
            {:extra-paths ["test"]
-            :extra-deps {lambdaisland/kaocha       {:mvn/version "RELEASE"}
-                         com.lambdaisland/kaocha-cljs  {:mvn/version "1.2.123"}
+            :extra-deps {lambdaisland/kaocha       {:mvn/version "1.70.1086"}
+                         com.lambdaisland/kaocha-cljs  {:mvn/version "1.4.130"}
                          org.clojure/clojurescript {:mvn/version "1.11.60"}
                          org.clojure/test.check    {:mvn/version "1.1.1"}}}}}


### PR DESCRIPTION
This PR changes our CI setup to:
- Use a test matrix instead of specifying jobs individually.
- Add Java 17 and 19.
- Update to the latest version of Clojure 1.10.