### PR TITLE
don't perform unnecessary work when diffing maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Fixed
 
+- Simplified internals when diffing maps for improved performance on many datasets.
+
 ## Changed
 
 # 2.8.190 (2023-03-30 / 34d5e17)

--- a/src/lambdaisland/deep_diff2/diff_impl.cljc
+++ b/src/lambdaisland/deep_diff2/diff_impl.cljc
@@ -108,20 +108,10 @@
    (map ->Insertion)
    (remove #(contains? exp %) act)))
 
-(let [exp {false 0, 0 0}
-      act {false 0, 0 0}
-      exp-ks (keys exp)
-      act-ks (concat (filter #(contains? (set (keys act)) %) exp-ks)
-                     (remove #(contains? (set exp-ks) %) (keys act)))
-      [del ins] (del+ins exp-ks act-ks)]
-  [del ins])
-(del+ins [0 false] [0 false])
-
 (defn diff-map [exp act]
   (first
    (let [exp-ks (keys exp)
-         act-ks (concat (filter #(contains? (set (keys act)) %) exp-ks)
-                        (remove #(contains? (set exp-ks) %) (keys act)))
+         act-ks (keys act)
          [del ins] (del+ins exp-ks act-ks)]
      (reduce
       (fn [[m idx] k]


### PR DESCRIPTION
I was seeing some pretty bad performance when performing a large diff and tracked down the primary cause. I'm certain there are other improvements that can be made but I'll keep the change small for now :). This change runs ~15x faster for my use case.

Math identity illustrating why this change is okay:

```
(A ∩ B) ∪ (B - A) = B
```

Before:
<img width="1290" alt="Screenshot 2023-06-05 at 11 10 20 AM" src="https://github.com/lambdaisland/deep-diff2/assets/124183906/429c8a3d-b970-46da-9421-1fa1085d7459">


After:
<img width="1242" alt="Screenshot 2023-06-05 at 11 23 14 AM" src="https://github.com/lambdaisland/deep-diff2/assets/124183906/26cdbabe-651d-4d16-bebc-5c8f27064186">
