### PR TITLE
Diff / preserve metadata on collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+- Diff / preserve metadata on collections
+
 ## Fixed
 
 Varying key order in maps should produce a consistent diff (#47)

--- a/test/lambdaisland/deep_diff2/diff_test.cljc
+++ b/test/lambdaisland/deep_diff2/diff_test.cljc
@@ -31,6 +31,9 @@
       (is (= []
              (diff/diff [] [])))
 
+      (is (= {:meta true}
+             (meta (diff/diff ^:meta [] ^:meta []))))
+
       (is (= [1 2 3]
              (diff/diff (into-array [1 2 3]) [1 2 3])))
 
@@ -68,6 +71,9 @@
       (is (= #{:a}
              (diff/diff #{:a} #{:a})))
 
+      (is (= {:meta true}
+             (meta (diff/diff ^:meta #{} ^:meta #{}))))
+
       (is (= #{(diff/->Insertion :a)}
              (diff/diff #{} #{:a})))
 
@@ -79,6 +85,9 @@
 
     (testing "maps"
       (is (= {} (diff/diff {} {})))
+
+      (is (= {:meta true}
+             (meta (diff/diff ^:meta {} ^:meta {}))))
 
       (is (= {:a (diff/->Mismatch 1 2)}
              (diff/diff {:a 1} {:a 2})))


### PR DESCRIPTION
<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->

I tend to use deep diff a lot in [Portal](https://github.com/djblue/portal) and like many visual tools, it leverages metadata to configure viewers. However, on diff all of the metadata is lost. This allows diffed values to retain metadata if unchanged or point out where certain metadata has changed.
